### PR TITLE
Fixed a bug in mV2ADC

### DIFF
--- a/picosdk/functions.py
+++ b/picosdk/functions.py
@@ -24,7 +24,7 @@ def adc2mV(bufferADC, range, maxADC):
 
     return bufferV
 
-def mV2adc(volts, range, maxADC):
+def mV2adc(millivolts, range, maxADC):
     """
         mV2adc(
                 float                   millivolts


### PR DESCRIPTION
there was a bug where the input parameter was named volts, but in the comments as well as in the function internally it was referred to and used under the name of millivolts
changed it so input parameter is also named millivolts

Fixes #.

Changes proposed in this pull request:

*
*
*
